### PR TITLE
feat: Address GitHub issues #43-44 - Token supply update and CoinGeck…

### DIFF
--- a/data/coingecko.json
+++ b/data/coingecko.json
@@ -1,0 +1,37 @@
+{
+  "source": "coingecko",
+  "timestamp": "2025-09-17T00:51:08Z",
+  "token": {
+    "symbol": "ROKO",
+    "name": "ROKO",
+    "contract_address": "0x6f6deb5db0c4994a8283a01d6cfeeb27fc3bbe9c",
+    "blockchain": "ethereum"
+  },
+  "price_data": {
+    "0x6f6deb5db0c4994a8283a01d6cfeeb27fc3bbe9c": {
+      "usd": 0.00174111,
+      "usd_market_cap": 0.0,
+      "usd_24h_vol": 0.25246148933559714,
+      "usd_24h_change": null,
+      "eur": 0.00157884,
+      "eur_market_cap": 0.0,
+      "eur_24h_vol": 0.2289318260680301,
+      "eur_24h_change": null,
+      "btc": 2.01398e-07,
+      "btc_market_cap": 0.0,
+      "btc_24h_vol": 2.9202768e-05,
+      "btc_24h_change": null,
+      "eth": 7.77e-06,
+      "eth_market_cap": 0.0,
+      "eth_24h_vol": 0.0011267039930684946,
+      "eth_24h_change": null,
+      "last_updated_at": 1582982365
+    }
+  },
+  "detailed_info": {},
+  "extraction_metadata": {
+    "script_version": "1.0",
+    "api_endpoint": "https://api.coingecko.com/api/v3",
+    "extraction_time": "2025-09-17T00:51:08Z"
+  }
+}

--- a/src/components/TokenStats/TokenStats.tsx
+++ b/src/components/TokenStats/TokenStats.tsx
@@ -1,12 +1,12 @@
 /**
  * Dynamic Token Statistics Component
  *
- * Displays real-time ROKO token statistics fetched from Etherscan API
+ * Displays real-time ROKO token statistics fetched from CoinGecko data
  */
 
 import React, { memo } from 'react';
 import { motion } from 'framer-motion';
-import { useTokenStats, useTokenInfo } from '../../hooks/useTokenStats';
+import { useCoinGeckoStats, useCoinGeckoTokenInfo } from '../../hooks/useCoinGeckoStats';
 import { formatTokenAmount, formatNumber } from '../../services/web3';
 import styles from './TokenStats.module.css';
 
@@ -64,10 +64,10 @@ export const TokenStats: React.FC<TokenStatsProps> = memo(({
   className = '',
   variant = 'default'
 }) => {
-  const { data: stats, isLoading, error, refetch, isConfigured } = useTokenStats({
+  const { data: stats, isLoading, error, refetch, isConfigured } = useCoinGeckoStats({
     refetchInterval: 60000 // Refresh every minute
   });
-  const { data: tokenInfo } = useTokenInfo();
+  const { data: tokenInfo } = useCoinGeckoTokenInfo();
 
   // Don't render if not configured and no fallback data
   if (!isConfigured && !stats) {
@@ -75,7 +75,7 @@ export const TokenStats: React.FC<TokenStatsProps> = memo(({
       <div className={`${styles.container} ${styles[variant]} ${className}`}>
         <div className={styles.notConfigured}>
           <p>Token statistics unavailable</p>
-          <small>Etherscan API key required</small>
+          <small>CoinGecko data not available</small>
         </div>
       </div>
     );
@@ -175,11 +175,11 @@ export const TokenStats: React.FC<TokenStatsProps> = memo(({
       <div className={styles.statusBar}>
         <div className={`${styles.statusDot} ${isLoading ? styles.loading : styles.connected}`} />
         <span className={styles.statusText}>
-          {isLoading ? 'Updating...' : 'Live data'}
+          {isLoading ? 'Updating...' : 'CoinGecko data'}
         </span>
-        {stats && (
+        {stats && stats.lastUpdated && (
           <span className={styles.lastUpdate}>
-            Last updated: {new Date().toLocaleTimeString()}
+            Last updated: {new Date(stats.lastUpdated).toLocaleTimeString()}
           </span>
         )}
       </div>

--- a/src/components/sections/Governance.tsx
+++ b/src/components/sections/Governance.tsx
@@ -34,7 +34,7 @@ interface Proposal {
 // TreasuryAllocation interface removed - Issue #14
 
 const daoStats: DAOStats = {
-  totalSupply: '1,000,000,000',
+  totalSupply: '369,369,369,369',
   totalHolders: '89,432',
   avgVotingPower: '2.8%'
   // Staking, validator, and treasury data removed

--- a/src/hooks/useCoinGeckoStats.ts
+++ b/src/hooks/useCoinGeckoStats.ts
@@ -1,0 +1,159 @@
+/**
+ * React hook for fetching and managing ROKO token statistics from CoinGecko
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { coingeckoService } from '../services/coingecko';
+import type { TokenHolderStats } from '../services/web3';
+
+interface UseCoinGeckoStatsOptions {
+  refetchInterval?: number;
+  enabled?: boolean;
+}
+
+interface UseCoinGeckoStatsReturn {
+  data: TokenHolderStats | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+  isConfigured: boolean;
+}
+
+export const useCoinGeckoStats = (options: UseCoinGeckoStatsOptions = {}): UseCoinGeckoStatsReturn => {
+  const { refetchInterval = 30000, enabled = true } = options; // Default 30 seconds
+
+  const [error, setError] = useState<string | null>(null);
+  // CoinGecko is always configured (uses static JSON file)
+  const isConfigured = true;
+
+  const {
+    data,
+    isLoading,
+    error: queryError,
+    refetch: queryRefetch
+  } = useQuery({
+    queryKey: ['coingeckoStats', 'roko'],
+    queryFn: async (): Promise<TokenHolderStats> => {
+      try {
+        setError(null);
+
+        // Reload data first (in case we want to fetch fresh data in the future)
+        await coingeckoService.reloadData();
+
+        // Get data from CoinGecko service
+        const price = coingeckoService.getCurrentPrice();
+        const marketCap = coingeckoService.getMarketCap();
+        const volume24h = coingeckoService.get24hVolume();
+        const change24h = coingeckoService.get24hChange();
+
+        // Return data in the expected format
+        return {
+          totalSupply: '369369369369000000000000000000', // 369,369,369,369 * 10^18 (wei format)
+          totalHolders: 89432, // This would come from another source
+          price: coingeckoService.getFormattedPrice('usd'),
+          marketCap: coingeckoService.getFormattedMarketCap(),
+          volume24h: coingeckoService.getFormatted24hVolume(),
+          change24h: coingeckoService.getFormatted24hChange(),
+          priceInETH: coingeckoService.getPriceInETH(),
+          priceInBTC: coingeckoService.getPriceInBTC(),
+          lastUpdated: coingeckoService.getLastUpdated().toISOString()
+        };
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Failed to fetch CoinGecko stats';
+        setError(errorMessage);
+        throw err;
+      }
+    },
+    enabled: enabled && isConfigured,
+    refetchInterval: refetchInterval,
+    staleTime: 30000, // Consider data stale after 30 seconds
+    gcTime: 300000, // Keep in cache for 5 minutes
+    retry: (failureCount) => {
+      // Retry up to 3 times
+      return failureCount < 3;
+    },
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+
+  const refetch = useCallback(() => {
+    setError(null);
+    queryRefetch();
+  }, [queryRefetch]);
+
+  // Handle query errors
+  useEffect(() => {
+    if (queryError) {
+      const errorMessage = queryError instanceof Error
+        ? queryError.message
+        : 'Failed to fetch CoinGecko statistics';
+      setError(errorMessage);
+    }
+  }, [queryError]);
+
+  return {
+    data: data || null,
+    isLoading,
+    error: error || (queryError?.message ?? null),
+    refetch,
+    isConfigured
+  };
+};
+
+/**
+ * Hook for getting token info from CoinGecko
+ */
+export const useCoinGeckoTokenInfo = () => {
+  const {
+    data,
+    isLoading,
+    error
+  } = useQuery({
+    queryKey: ['coingeckoTokenInfo', 'roko'],
+    queryFn: () => {
+      const tokenInfo = coingeckoService.getTokenInfo();
+      return {
+        name: tokenInfo.name,
+        symbol: tokenInfo.symbol,
+        address: tokenInfo.contract_address,
+        decimals: 18,
+        blockchain: tokenInfo.blockchain
+      };
+    },
+    staleTime: 3600000, // Token info rarely changes, cache for 1 hour
+    gcTime: 3600000,
+    retry: 2
+  });
+
+  return {
+    data,
+    isLoading,
+    error: error?.message ?? null
+  };
+};
+
+/**
+ * Hook for checking if CoinGecko data is stale
+ */
+export const useCoinGeckoStatus = () => {
+  const [isStale, setIsStale] = useState(false);
+
+  useEffect(() => {
+    const checkStale = () => {
+      setIsStale(coingeckoService.isDataStale());
+    };
+
+    // Check immediately
+    checkStale();
+
+    // Check every minute
+    const interval = setInterval(checkStale, 60000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return {
+    isStale,
+    lastUpdated: coingeckoService.getLastUpdated()
+  };
+};

--- a/src/services/coingecko.ts
+++ b/src/services/coingecko.ts
@@ -1,0 +1,253 @@
+// CoinGecko price data service
+import coingeckoData from '../../data/coingecko.json';
+
+export interface CoinGeckoPriceData {
+  usd: number;
+  usd_market_cap: number;
+  usd_24h_vol: number;
+  usd_24h_change: number | null;
+  eur: number;
+  eur_market_cap: number;
+  eur_24h_vol: number;
+  eur_24h_change: number | null;
+  btc: number;
+  btc_market_cap: number;
+  btc_24h_vol: number;
+  btc_24h_change: number | null;
+  eth: number;
+  eth_market_cap: number;
+  eth_24h_vol: number;
+  eth_24h_change: number | null;
+  last_updated_at: number;
+}
+
+export interface CoinGeckoData {
+  source: string;
+  timestamp: string;
+  token: {
+    symbol: string;
+    name: string;
+    contract_address: string;
+    blockchain: string;
+  };
+  price_data: {
+    [address: string]: CoinGeckoPriceData;
+  };
+  detailed_info: any;
+  extraction_metadata: {
+    script_version: string;
+    api_endpoint: string;
+    extraction_time: string;
+  };
+}
+
+class CoinGeckoService {
+  private data: CoinGeckoData;
+  private contractAddress: string;
+
+  constructor() {
+    this.data = coingeckoData as CoinGeckoData;
+    this.contractAddress = this.data.token.contract_address.toLowerCase();
+  }
+
+  /**
+   * Get current price in USD
+   */
+  getCurrentPrice(): number {
+    const priceData = this.getPriceData();
+    return priceData?.usd || 0;
+  }
+
+  /**
+   * Get 24h price change percentage
+   */
+  get24hChange(): number | null {
+    const priceData = this.getPriceData();
+    return priceData?.usd_24h_change || null;
+  }
+
+  /**
+   * Get 24h trading volume in USD
+   */
+  get24hVolume(): number {
+    const priceData = this.getPriceData();
+    return priceData?.usd_24h_vol || 0;
+  }
+
+  /**
+   * Get market cap in USD
+   */
+  getMarketCap(): number {
+    const priceData = this.getPriceData();
+    const price = priceData?.usd || 0;
+    // Calculate market cap using the new total supply
+    const totalSupply = 369369369369; // 369,369,369,369
+    return price * totalSupply;
+  }
+
+  /**
+   * Get price in ETH
+   */
+  getPriceInETH(): number {
+    const priceData = this.getPriceData();
+    return priceData?.eth || 0;
+  }
+
+  /**
+   * Get price in BTC
+   */
+  getPriceInBTC(): number {
+    const priceData = this.getPriceData();
+    return priceData?.btc || 0;
+  }
+
+  /**
+   * Get formatted price display
+   */
+  getFormattedPrice(currency: 'usd' | 'eth' | 'btc' = 'usd'): string {
+    const priceData = this.getPriceData();
+    if (!priceData) return '$0.00';
+
+    switch (currency) {
+      case 'usd':
+        return `$${this.formatNumber(priceData.usd, 6)}`;
+      case 'eth':
+        return `${this.formatNumber(priceData.eth, 8)} ETH`;
+      case 'btc':
+        return `${this.formatNumber(priceData.btc, 8)} BTC`;
+      default:
+        return `$${this.formatNumber(priceData.usd, 6)}`;
+    }
+  }
+
+  /**
+   * Get formatted market cap
+   */
+  getFormattedMarketCap(): string {
+    const marketCap = this.getMarketCap();
+    return this.formatLargeNumber(marketCap);
+  }
+
+  /**
+   * Get formatted 24h volume
+   */
+  getFormatted24hVolume(): string {
+    const volume = this.get24hVolume();
+    return this.formatLargeNumber(volume);
+  }
+
+  /**
+   * Get formatted 24h change
+   */
+  getFormatted24hChange(): string {
+    const change = this.get24hChange();
+    if (change === null) return '0.00%';
+
+    const sign = change >= 0 ? '+' : '';
+    return `${sign}${change.toFixed(2)}%`;
+  }
+
+  /**
+   * Get last update timestamp
+   */
+  getLastUpdated(): Date {
+    const priceData = this.getPriceData();
+    if (!priceData) return new Date();
+    return new Date(priceData.last_updated_at * 1000);
+  }
+
+  /**
+   * Check if data is stale (older than 1 hour)
+   */
+  isDataStale(): boolean {
+    const lastUpdated = this.getLastUpdated();
+    const now = new Date();
+    const hourInMs = 60 * 60 * 1000;
+    return (now.getTime() - lastUpdated.getTime()) > hourInMs;
+  }
+
+  /**
+   * Get all price data
+   */
+  getAllPriceData(): CoinGeckoPriceData | null {
+    return this.getPriceData();
+  }
+
+  /**
+   * Get token info
+   */
+  getTokenInfo() {
+    return this.data.token;
+  }
+
+  // Private helper methods
+  private getPriceData(): CoinGeckoPriceData | null {
+    // Try different address formats
+    const addresses = [
+      this.contractAddress,
+      this.contractAddress.toLowerCase(),
+      '0x' + this.contractAddress.slice(2).toLowerCase()
+    ];
+
+    for (const address of addresses) {
+      if (this.data.price_data[address]) {
+        return this.data.price_data[address];
+      }
+    }
+
+    return null;
+  }
+
+  private formatNumber(value: number, decimals: number = 2): string {
+    if (value === 0) return '0';
+
+    // For very small numbers
+    if (value < 0.01 && value > 0) {
+      return value.toFixed(decimals);
+    }
+
+    return value.toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: decimals
+    });
+  }
+
+  private formatLargeNumber(value: number): string {
+    if (value === 0) return '$0';
+
+    const absValue = Math.abs(value);
+    const sign = value < 0 ? '-' : '';
+
+    if (absValue >= 1e9) {
+      return `${sign}$${(absValue / 1e9).toFixed(2)}B`;
+    } else if (absValue >= 1e6) {
+      return `${sign}$${(absValue / 1e6).toFixed(2)}M`;
+    } else if (absValue >= 1e3) {
+      return `${sign}$${(absValue / 1e3).toFixed(2)}K`;
+    } else {
+      return `${sign}$${absValue.toFixed(2)}`;
+    }
+  }
+
+  /**
+   * Reload data (for future dynamic loading)
+   * This could be expanded to fetch fresh data from an API
+   */
+  async reloadData(): Promise<void> {
+    try {
+      // In production, this would fetch from the actual CoinGecko API
+      // For now, we're using the static JSON file
+      // const response = await fetch('/data/coingecko.json');
+      // this.data = await response.json();
+      console.log('CoinGecko data reloaded');
+    } catch (error) {
+      console.error('Failed to reload CoinGecko data:', error);
+    }
+  }
+}
+
+// Export singleton instance
+export const coingeckoService = new CoinGeckoService();
+
+// Export default for convenience
+export default coingeckoService;

--- a/src/services/web3/types.ts
+++ b/src/services/web3/types.ts
@@ -9,6 +9,10 @@ export interface TokenHolderStats {
   marketCap?: string;
   volume24h?: string;
   priceChange24h?: string;
+  change24h?: string;
+  priceInETH?: number;
+  priceInBTC?: number;
+  lastUpdated?: string;
 }
 
 export interface EtherscanTokenResponse {
@@ -29,4 +33,5 @@ export interface TokenInfo {
   symbol: string;
   decimals: number;
   totalSupply: string;
+  blockchain?: string;
 }


### PR DESCRIPTION
…o integration

Issue #43: Update total supply
- Changed total supply from 1,000,000,000 to 369,369,369,369 in Governance component

Issue #44: Add CoinGecko price data support
- Created data/coingecko.json with static price data from CoinGecko API
- Implemented CoinGeckoService to parse and format price data
- Created useCoinGeckoStats hook to replace Etherscan pricing
- Updated TokenStats component to use CoinGecko data instead of Etherscan
- Added support for ETH and BTC price conversions
- Enhanced TokenHolderStats type with additional price fields

Benefits:
- Price data now sourced from CoinGecko for better reliability
- Support for multiple currency conversions (USD, ETH, BTC)
- Static JSON file approach allows for easy updates without API keys
- Market cap calculated using the new total supply