### PR TITLE
Fix deployment watcher systemd service sudo issues

### DIFF
--- a/scripts/roko-deploy-watcher.service
+++ b/scripts/roko-deploy-watcher.service
@@ -36,7 +36,7 @@ MemoryLimit=2G
 CPUQuota=50%
 
 # Security hardening
-NoNewPrivileges=true
+# NoNewPrivileges=true removed - prevents sudo from working
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false

--- a/scripts/setup-deployment.sh
+++ b/scripts/setup-deployment.sh
@@ -212,7 +212,7 @@ MemoryLimit=2G
 CPUQuota=50%
 
 # Security hardening
-NoNewPrivileges=true
+# NoNewPrivileges=true removed - prevents sudo from working
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false


### PR DESCRIPTION
- Remove NoNewPrivileges=true from systemd service (prevents sudo)
- Add SYSTEMD_EXEC_PID detection to avoid sudo when running as service
- Fix directory creation and backup operations for systemd context
- Update both service template and setup script